### PR TITLE
fix(release): publish package to GitHub packages

### DIFF
--- a/.github/workflows/release.node.js.yml
+++ b/.github/workflows/release.node.js.yml
@@ -23,6 +23,7 @@ jobs:
       contents: write
       issues: write
       packages: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/github"
+      "@semantic-release/github",
+      "@semantic-release/npm"
     ]
   }
 }


### PR DESCRIPTION
Enable `@semantic-release/npm` so the package will be published to
GitHub packages
