### PR TITLE
Skip PR build on push to master

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,8 +4,6 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 


### PR DESCRIPTION
The PR build should only be triggered when changes are pushed to a PR
branch, release build with be triggered on push to master branch
