### PR TITLE
chore(deps): Remove swagger-methods dependency

### DIFF
--- a/lib/swagger-methods.js
+++ b/lib/swagger-methods.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put'];

--- a/lib/types/path.js
+++ b/lib/types/path.js
@@ -29,7 +29,7 @@ var JsonRefs = require('json-refs');
 var Operation = require('./operation');
 var Parameter = require('./parameter');
 var pathToRegexp = require('path-to-regexp');
-var supportedHttpMethods = require('swagger-methods');
+var supportedHttpMethods = require('../swagger-methods');
 
 /**
  * The Path object.

--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -27,7 +27,7 @@
 var _ = require('lodash');
 var helpers = require('../helpers');
 var JsonRefs = require('json-refs');
-var supportedHttpMethods = require('swagger-methods');
+var supportedHttpMethods = require('../swagger-methods');
 var swaggerSchema = require('swagger-schema-official/schema');
 
 function getSchemaProperties (schema) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "sway-node",
+  "name": "@frodeaa/sway-node",
   "version": "0.0.0-development",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sway-node",
+      "name": "@frodeaa/sway-node",
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
@@ -15,7 +15,6 @@
         "json-schema-faker": "^0.5.0-rcv.46",
         "lodash": "^4.17.10",
         "path-to-regexp": "^6.2.1",
-        "swagger-methods": "^3.0.2",
         "swagger-schema-official": "2.0.0-bab6bed",
         "z-schema": "^5.0.5"
       },
@@ -26,11 +25,6 @@
         "mocha": "^10.2.0",
         "semantic-release": "^21.0.1"
       }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -8184,17 +8178,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-vh7FGt7d3+Y/rPUyCZw5LAmwS5xB162yWmqLFVIGyg8MUphPlDqf1Zb/NFWZVXQA63DpSc8i4Gg1J+hx/bD6VA==",
-      "dependencies": {
-        "@apidevtools/swagger-methods": "3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/swagger-schema-official": {
       "version": "2.0.0-bab6bed",
       "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
@@ -8596,11 +8579,6 @@
     }
   },
   "dependencies": {
-    "@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
-    },
     "@babel/code-frame": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -14435,14 +14413,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-vh7FGt7d3+Y/rPUyCZw5LAmwS5xB162yWmqLFVIGyg8MUphPlDqf1Zb/NFWZVXQA63DpSc8i4Gg1J+hx/bD6VA==",
-      "requires": {
-        "@apidevtools/swagger-methods": "3.0.2"
-      }
     },
     "swagger-schema-official": {
       "version": "2.0.0-bab6bed",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "json-schema-faker": "^0.5.0-rcv.46",
     "lodash": "^4.17.10",
     "path-to-regexp": "^6.2.1",
-    "swagger-methods": "^3.0.2",
     "swagger-schema-official": "2.0.0-bab6bed",
     "z-schema": "^5.0.5"
   },

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -30,7 +30,7 @@ var _ = require('lodash');
 var assert = require('assert');
 var tHelpers = require('./helpers');
 var JsonRefs = require('json-refs');
-var supportedHttpMethods = require('swagger-methods');
+var supportedHttpMethods = require('../lib/swagger-methods');
 var Sway = tHelpers.getSway();
 
 function getOperationCount (pathDef) {


### PR DESCRIPTION
The dependency is no longer being maintained and we can easily let it be
replaced by our own implementation
